### PR TITLE
Cheer 도메인 기능 수정

### DIFF
--- a/src/main/java/com/example/mokkoji/domain/cheer/controller/CheerController.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/controller/CheerController.java
@@ -1,4 +1,103 @@
 package com.example.mokkoji.domain.cheer.controller;
 
+import com.example.mokkoji.domain.cheer.controller.dto.request.CheerCommentRequest;
+import com.example.mokkoji.domain.cheer.controller.dto.request.CheerRequest;
+import com.example.mokkoji.domain.cheer.controller.dto.response.CheerCommentResponse;
+import com.example.mokkoji.domain.cheer.controller.dto.response.CheerResponse;
+import com.example.mokkoji.domain.cheer.service.CheerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/messages")
+@RequiredArgsConstructor
 public class CheerController {
+
+    private final CheerService cheerService;
+
+    // 응원글 작성
+    @PostMapping
+    public ResponseEntity<Void> writeCheer(@RequestBody CheerRequest request) {
+        cheerService.writeCheer(request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 응원글 수정
+    @PatchMapping("/{messageId}")
+    public ResponseEntity<Void> updateCheer(@PathVariable Long messageId,
+                                            @RequestBody Map<String, String> body) {
+        cheerService.updateCheer(messageId, body.get("content"));
+        return ResponseEntity.ok().build();
+    }
+
+    // 응원글 삭제
+    @DeleteMapping("/{messageId}")
+    public ResponseEntity<Void> deleteCheer(@PathVariable Long messageId) {
+        cheerService.deleteCheer(messageId);
+        return ResponseEntity.ok().build();
+    }
+
+
+
+    // 좋아요 기능
+    @PostMapping("/{messageId}/like")
+    public ResponseEntity<Void> likeCheer(@PathVariable Long messageId) {
+        cheerService.likeCheer(messageId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 댓글 작성
+    @PostMapping("/{messageId}/comments")
+    public ResponseEntity<Void> addComment(@PathVariable Long messageId,
+                                           @RequestBody CheerCommentRequest request) {
+        cheerService.addComment(messageId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 댓글 목록 조회
+    @GetMapping("/{messageId}/comments")
+    public ResponseEntity<List<CheerCommentResponse>> getComments(@PathVariable Long messageId) {
+        return ResponseEntity.ok(cheerService.getCommentList(messageId));
+    }
+    //태그 필터링
+    //전체 피드 조회(인기순)
+    @GetMapping("/feed")
+    public ResponseEntity<List<CheerResponse>> getFeed(
+            @RequestParam(defaultValue = "popular") String sortBy,  // 인기순이 기본
+            @RequestParam(required = false) String tag
+    ) {
+        return ResponseEntity.ok(cheerService.getAllCheersFiltered(sortBy, tag));
+    }
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<List<CheerResponse>> getMyCheers(@PathVariable Long userId) {
+        return ResponseEntity.ok(cheerService.getCheersByUser(userId));
+    }
+    //댓글 삭제 수정
+    @PatchMapping("/comments/{commentId}/users/{userId}")
+    public ResponseEntity<Void> updateComment(@PathVariable Long commentId,
+                                              @PathVariable Long userId,
+                                              @RequestBody Map<String, String> body) {
+        cheerService.updateComment(commentId, userId, body.get("content"));
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/comments/{commentId}/users/{userId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId,
+                                              @PathVariable Long userId) {
+        cheerService.deleteComment(commentId, userId);
+        return ResponseEntity.ok().build();
+    }
+    @PostMapping("/{messageId}/like/users/{userId}")
+    public ResponseEntity<Void> likeCheer(@PathVariable Long messageId,
+                                          @PathVariable Long userId) {
+        cheerService.likeCheer(messageId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+
 }

--- a/src/main/java/com/example/mokkoji/domain/cheer/controller/CheerImageController.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/controller/CheerImageController.java
@@ -1,0 +1,33 @@
+package com.example.mokkoji.domain.cheer.controller;
+
+import com.example.mokkoji.domain.cheer.service.CheerImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/messages/images")
+@RequiredArgsConstructor
+public class CheerImageController {
+
+    private final CheerImageService cheerImageService;
+
+    @PostMapping
+    public ResponseEntity<String> uploadImage(@RequestParam("image") MultipartFile file) {
+        try {
+            String url = cheerImageService.saveImage(file);
+            return ResponseEntity.ok(url);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이미지 업로드 실패");
+        }
+    }
+}
+
+

--- a/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/request/CheerCommentRequest.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/request/CheerCommentRequest.java
@@ -1,0 +1,9 @@
+package com.example.mokkoji.domain.cheer.controller.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CheerCommentRequest {
+    private Long userId;
+    private String content;
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/request/CheerRequest.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/request/CheerRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public record CheerRequest(
         Long storeId,
+        Long userId,
         String content,
         List<TagType> tagList,
         List<String> imageList

--- a/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/response/CheerCommentResponse.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/response/CheerCommentResponse.java
@@ -1,0 +1,25 @@
+package com.example.mokkoji.domain.cheer.controller.dto.response;
+
+import com.example.mokkoji.domain.cheer.entity.CheerComment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CheerCommentResponse {
+    private Long commentId;
+    private String content;
+    private String writerUsername;
+    private LocalDateTime createdAt;
+
+    public static CheerCommentResponse from(CheerComment comment) {
+        return CheerCommentResponse.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .writerUsername(comment.getUser().getUsername()) // User에 getUsername() 있음
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/response/CheerResponse.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/controller/dto/response/CheerResponse.java
@@ -1,0 +1,34 @@
+package com.example.mokkoji.domain.cheer.controller.dto.response;
+
+import com.example.mokkoji.domain.cheer.entity.Cheer;
+import com.example.mokkoji.domain.tag.entity.TagType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class CheerResponse {
+    private Long cheerId;
+    private String content;
+    private String writerNickname;
+    private int likeCount;
+    private List<TagType> tagList;
+    private LocalDateTime createdAt;
+    private List<String> imageList;
+
+    // 정적 팩토리 메서드 추가
+    public static CheerResponse from(Cheer cheer) {
+        return CheerResponse.builder()
+                .cheerId(cheer.getId())
+                .content(cheer.getContent())
+                .writerNickname(cheer.getUser().getUsername())  // ✅ username으로 변경
+                .likeCount(cheer.getLikeCount())
+                .imageList(cheer.getImageList())
+                .tagList(cheer.getCheerTagList())
+                .createdAt(cheer.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/entity/Cheer.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/entity/Cheer.java
@@ -1,23 +1,23 @@
 package com.example.mokkoji.domain.cheer.entity;
+
 import com.example.mokkoji.domain.store.entity.Store;
 import com.example.mokkoji.domain.tag.entity.TagType;
 import com.example.mokkoji.domain.user.entity.User;
 import com.example.mokkoji.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
+@Getter
+@NoArgsConstructor
 @AllArgsConstructor
-@Getter @NoArgsConstructor
+@Builder
 @Table(name = "cheer")
 public class Cheer extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,8 +26,8 @@ public class Cheer extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "cheer_tag", joinColumns = @JoinColumn(name = "cheer_id"))
     @Column(name = "tag_type")
+    @Builder.Default
     private List<TagType> cheerTagList = new ArrayList<>();
-
 
     private String content;
 
@@ -36,12 +36,22 @@ public class Cheer extends BaseTimeEntity {
     private User user;
 
     @OneToMany(mappedBy = "cheer", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<CheerComment> cheerCommentList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
 
+    @Column(name = "like_count")
+    @Builder.Default
+    private int likeCount = 0;
+
+    @ElementCollection
+    @CollectionTable(name = "cheer_images", joinColumns = @JoinColumn(name = "cheer_id"))
+    @Column(name = "image_url")
+    @Builder.Default
+    private List<String> imageList = new ArrayList<>();
 
     public static Cheer of(User user, String content, Store store) {
         return Cheer.builder()
@@ -67,4 +77,11 @@ public class Cheer extends BaseTimeEntity {
         store.incrementCheerCount();
     }
 
+    public void addLike() {
+        this.likeCount++;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/example/mokkoji/domain/cheer/entity/CheerComment.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/entity/CheerComment.java
@@ -32,6 +32,9 @@ public class CheerComment extends BaseTimeEntity {
         this.user = user;
         this.cheer = cheer;
     }
+    public void updateContent(String content) {
+        this.content = content;
+    }
 
     // 연관관계 편의 메서드
     public void setCheer(Cheer cheer) {

--- a/src/main/java/com/example/mokkoji/domain/cheer/entity/CheerLike.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/entity/CheerLike.java
@@ -1,0 +1,28 @@
+package com.example.mokkoji.domain.cheer.entity;
+
+import com.example.mokkoji.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "cheer_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "cheer_id"})
+})
+public class CheerLike {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cheer_id")
+    private Cheer cheer;
+}
+

--- a/src/main/java/com/example/mokkoji/domain/cheer/repository/CheerCommentRepository.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/repository/CheerCommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.mokkoji.domain.cheer.repository;
+
+import com.example.mokkoji.domain.cheer.entity.CheerComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheerCommentRepository extends JpaRepository<CheerComment, Long> {
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/repository/CheerLikeRepository.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/repository/CheerLikeRepository.java
@@ -1,0 +1,12 @@
+package com.example.mokkoji.domain.cheer.repository;
+
+import com.example.mokkoji.domain.cheer.entity.Cheer;
+import com.example.mokkoji.domain.cheer.entity.CheerLike;
+import com.example.mokkoji.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CheerLikeRepository extends JpaRepository<CheerLike, Long> {
+    Optional<CheerLike> findByUserAndCheer(User user, Cheer cheer);
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/repository/CheerRepository.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/repository/CheerRepository.java
@@ -1,0 +1,16 @@
+package com.example.mokkoji.domain.cheer.repository;
+
+import com.example.mokkoji.domain.cheer.entity.Cheer;
+import com.example.mokkoji.domain.store.entity.Store;
+import com.example.mokkoji.domain.tag.entity.TagType;
+import com.example.mokkoji.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CheerRepository extends JpaRepository<Cheer, Long> {
+    List<Cheer> findByStore(Store store);
+    List<Cheer> findByCheerTagListContaining(TagType tagType);
+    List<Cheer> findByUser(User user);
+
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/service/CheerImageService.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/service/CheerImageService.java
@@ -1,0 +1,28 @@
+package com.example.mokkoji.domain.cheer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+
+@Service
+@RequiredArgsConstructor
+public class CheerImageService {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    public String saveImage(MultipartFile file) throws IOException {
+        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        Path path = Paths.get(uploadDir + filename);
+        Files.createDirectories(path.getParent());
+        Files.write(path, file.getBytes());
+        return "/images/" + filename;
+    }
+}

--- a/src/main/java/com/example/mokkoji/domain/cheer/service/CheerService.java
+++ b/src/main/java/com/example/mokkoji/domain/cheer/service/CheerService.java
@@ -1,9 +1,192 @@
 package com.example.mokkoji.domain.cheer.service;
 
+import com.example.mokkoji.domain.cheer.controller.dto.request.CheerCommentRequest;
+import com.example.mokkoji.domain.cheer.controller.dto.request.CheerRequest;
+import com.example.mokkoji.domain.cheer.controller.dto.response.CheerCommentResponse;
+import com.example.mokkoji.domain.cheer.controller.dto.response.CheerResponse;
+import com.example.mokkoji.domain.cheer.entity.Cheer;
+import com.example.mokkoji.domain.cheer.entity.CheerComment;
+import com.example.mokkoji.domain.cheer.repository.CheerCommentRepository;
+import com.example.mokkoji.domain.cheer.repository.CheerLikeRepository;
+import com.example.mokkoji.domain.cheer.repository.CheerRepository;
+import com.example.mokkoji.domain.store.entity.Store;
+import com.example.mokkoji.domain.store.repository.StoreRepository;
+import com.example.mokkoji.domain.tag.entity.TagType;
+import com.example.mokkoji.domain.user.entity.User;
+import com.example.mokkoji.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.example.mokkoji.domain.cheer.entity.CheerLike;
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class CheerService {
+
+    private final CheerRepository cheerRepository;
+    private final CheerCommentRepository cheerCommentRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+
+    // 응원글 작성
+    public void writeCheer(CheerRequest request) {
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Store store = storeRepository.findById(request.storeId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다."));
+
+        Cheer cheer = Cheer.builder()
+                .content(request.content())
+                .cheerTagList(request.tagList())
+                .user(user)
+                .store(store)
+                .build();
+
+        cheerRepository.save(cheer);
+    }
+
+    // 응원글 수정
+    public void updateCheer(Long messageId, String newContent) {
+        Cheer cheer = cheerRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("응원글이 존재하지 않습니다."));
+
+        cheer.updateContent(newContent);
+    }
+
+    // 응원글 삭제
+    public void deleteCheer(Long messageId) {
+        Cheer cheer = cheerRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("응원글이 존재하지 않습니다."));
+
+        cheerRepository.delete(cheer);
+    }
+
+    // 전체 응원글 피드 정렬 조회
+    public List<CheerResponse> getAllCheersSorted(String sortBy) {
+        List<Cheer> cheers = cheerRepository.findAll();
+
+        if (sortBy.equals("popular")) {
+            cheers.sort((a, b) -> Integer.compare(b.getLikeCount(), a.getLikeCount()));
+        } else {
+            cheers.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
+        }
+
+        return cheers.stream()
+                .map(CheerResponse::from)
+                .toList();
+    }
+
+    // 좋아요
+    public void likeCheer(Long messageId) {
+        Cheer cheer = cheerRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("응원글이 존재하지 않습니다."));
+
+        cheer.addLike();
+    }
+
+    // 댓글 작성
+    public void addComment(Long messageId, CheerCommentRequest request) {
+        Cheer cheer = cheerRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("응원글이 존재하지 않습니다."));
+
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        CheerComment comment = CheerComment.builder()
+                .cheer(cheer)
+                .user(user)
+                .content(request.getContent())
+                .build();
+
+        cheerCommentRepository.save(comment);
+        cheer.addCheerComment(comment);
+    }
+
+    // 댓글 목록 조회
+    public List<CheerCommentResponse> getCommentList(Long messageId) {
+        Cheer cheer = cheerRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("응원글이 존재하지 않습니다."));
+
+        return cheer.getCheerCommentList().stream()
+                .map(CheerCommentResponse::from)
+                .toList();
+    }
+    //태그 필터링 기능
+    public List<CheerResponse> getAllCheersFiltered(String sortBy, String tag) {
+        List<Cheer> cheers;
+
+        if (tag != null) {
+            TagType tagType = TagType.valueOf(tag.toUpperCase());  // ex: "가성비굿" → GASEONBI_GOOD
+            cheers = cheerRepository.findByCheerTagListContaining(tagType);
+        } else {
+            cheers = cheerRepository.findAll();
+        }
+
+        if (sortBy.equals("popular")) {
+            cheers.sort((a, b) -> Integer.compare(b.getLikeCount(), a.getLikeCount()));
+        } else {
+            cheers.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
+        }
+
+        return cheers.stream()
+                .map(CheerResponse::from)
+                .toList();
+    }
+    //내 응원글 조회
+    public List<CheerResponse> getCheersByUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        return cheerRepository.findByUser(user).stream()
+                .map(CheerResponse::from)
+                .toList();
+    }
+    //댓글 수정 & 삭제 기능
+    @Transactional
+    public void updateComment(Long commentId, Long userId, String newContent) {
+        CheerComment comment = cheerCommentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("본인 댓글만 수정 가능합니다.");
+        }
+
+        comment.updateContent(newContent);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        CheerComment comment = cheerCommentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("본인 댓글만 삭제 가능합니다.");
+        }
+
+        cheerCommentRepository.delete(comment);
+    }
+    //좋아요 중복 방지
+    @Autowired
+    private CheerLikeRepository cheerLikeRepository;
+
+    public void likeCheer(Long messageId, Long userId) {
+        Cheer cheer = cheerRepository.findById(messageId)
+                .orElseThrow(() -> new IllegalArgumentException("응원글이 존재하지 않습니다."));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        // 이미 좋아요 한 경우 무시
+        if (cheerLikeRepository.findByUserAndCheer(user, cheer).isPresent()) {
+            return;
+        }
+
+        cheer.addLike();  // 좋아요 수 증가
+        cheerLikeRepository.save(CheerLike.builder().user(user).cheer(cheer).build());
+    }
+
+
+
 }

--- a/src/main/java/com/example/mokkoji/global/config/WebConfig.java
+++ b/src/main/java/com/example/mokkoji/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.example.mokkoji.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadDir);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,15 @@ springdoc.use-fqn=true
 springdoc.swagger-ui.operations-sorter=method
 springdoc.swagger-ui.tags-sorter=alpha
 springdoc.swagger-ui.display-request-duration=true
+
+# ==============================
+# ?? ??? ??? ??
+# ==============================
+file.upload-dir=uploads/images/
+
+
+# Swagger ?? ?? (SpringDoc 2.x ??)
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/swagger-ui.html
+


### PR DESCRIPTION
## 📌 개요
- 응원 도메인(Cheer) 관련 기능 구현

## ✅ 구현 기능 목록
- 응원글 등록 (텍스트, 태그, 이미지 포함)
- 응원글 수정 / 삭제
- 응원글 목록 조회 (정렬: 인기순 / 최신순)
- 태그 필터링 기능
- 이미지 업로드 기능 (멀티파트)
- 댓글 작성 / 수정 / 삭제
- 좋아요 기능 (중복 방지 포함)
- 내 응원글 조회

## 🗂️ API 명세 요약
| 메서드 | URL | 설명 |
|--------|-----|------|
| POST | `/api/messages` | 응원글 등록 |
| PATCH | `/api/messages/{messageId}` | 응원글 수정 |
| DELETE | `/api/messages/{messageId}` | 응원글 삭제 |
| GET | `/api/messages/feed?sortBy=popular&tag=...` | 응원글 목록 조회 |
| GET | `/api/messages/users/{userId}` | 내 응원글 조회 |
| POST | `/api/messages/{messageId}/comments` | 댓글 작성 |
| PATCH | `/api/messages/comments/{commentId}/users/{userId}` | 댓글 수정 |
| DELETE | `/api/messages/comments/{commentId}/users/{userId}` | 댓글 삭제 |
| POST | `/api/messages/{messageId}/like/users/{userId}` | 좋아요 기능 |
| POST | `/api/messages/images` | 이미지 업로드 |

## ⚠️ 주의사항
- `.gitignore`에 `DockerDesktopWSL/` 포함 (대용량 파일 제외)
- Swagger 경로: `/swagger-ui/index.html`
